### PR TITLE
Fix undefined locsl variable "path" in Magic#load.

### DIFF
--- a/lib/ffi-magic.rb
+++ b/lib/ffi-magic.rb
@@ -42,6 +42,8 @@ class Magic
 
   Error = Class.new(StandardError)
 
+  attr_reader :path, :flags
+
   def self.compile(path)
     cookie = magic_open(NONE)
 
@@ -99,10 +101,11 @@ class Magic
     magic_check(@cookie, path) == 0
   end
 
-  def load
+  def load(path = @path)
     unless magic_load(@cookie, path) == 0
       raise Error, "failed load: #{magic_error(@cookie)}"
     end
+    @path = path
   end
 
   def close


### PR DESCRIPTION
This fixes the following:

  irb(main):001:0> require 'ffi-magic'
  => true
  irb(main):002:0> magic = Magic.new
  => #<Magic:0x007fea14143678 @flags=0, @path=nil, @cookie=#<FFI::Pointer address=0x007fea1358f7d0>>
  irb(main):003:0> magic.load
  NameError: undefined local variable or method `path' for #Magic:0x007fea14143678

Plus adds two new attribute readers: "flags" and "path" for convenience.

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
